### PR TITLE
Fix '--format' argument

### DIFF
--- a/playerctl.el
+++ b/playerctl.el
@@ -110,7 +110,7 @@
   "Get metadata from playerctl player."
   (interactive)
   (playerctl--command-with-arg
-   "metadata" "--format" "{{ playerName }} {{ lc(status) }}: {{ artist }} - {{ album }} - {{ title }}" ""))
+   "metadata" "--format={{ playerName }} {{ lc(status) }}: {{ artist }} - {{ album }} - {{ title }}" ""))
 
 (provide 'playerctl)
 ;;; playerctl.el ends here


### PR DESCRIPTION
This fixes the following error.

```
playerctl-metadata: Wrong number of arguments: (lambda (cmd arg msg) (let ((proc (start-process "playerctl.el" "*player\
ctl*" "playerctl" cmd arg))) (if (equal cmd "status") (set-process-filter proc #'(lambda (proc line) (message "Status :\
 %s" line))) (message msg)))), 4
```